### PR TITLE
benchmark timeseries commit workflow to run only in upstream repo

### DIFF
--- a/.github/workflows/pytest_benchmark_commit.yml
+++ b/.github/workflows/pytest_benchmark_commit.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
+    # only run this workflow on the upstream
+    if: github.repository == 'moj-analytical-services/splink'
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python


### PR DESCRIPTION
this stops this workflow running on `master` in fork repos that have enabled actions to run - such as you might do when working on modifying the actions themselves. With this workflow running you end up with many spurious commits which are out of sync with upstream, and involves a lot of fiddling about to ensure they do not end up polluting the main repo.

check this indeed does not run in fork